### PR TITLE
[squid:S1244] Floating point numbers should not be tested for equality

### DIFF
--- a/library/src/main/java/com/etiennelawlor/trestle/library/Trestle.java
+++ b/library/src/main/java/com/etiennelawlor/trestle/library/Trestle.java
@@ -179,7 +179,7 @@ public class Trestle {
 
     private static void setUpRelativeSizeSpan(Span span, SpannableString ss, int start, int end) {
         float relativeSize = span.getRelativeSize();
-        if (relativeSize != 0) {
+        if (Float.floatToRawIntBits(relativeSize) != 0) {
             ss.setSpan(
                 new RelativeSizeSpan(relativeSize),
                 start,
@@ -273,7 +273,7 @@ public class Trestle {
 
     private static void setUpScaleXSpan(Span span, SpannableString ss, int start, int end) {
         float scaleX = span.getScaleX();
-        if (scaleX != 0) {
+        if (Float.floatToRawIntBits(scaleX) != 0) {
             ss.setSpan(
                 new ScaleXSpan(scaleX),
                 start,


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1244 - “Floating point numbers should not be tested for equality”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1244

Please let me know if you have any questions.
Ayman Abdelghany.
