### PR TITLE
[squid:UselessParenthesesCheck] Useless parentheses around expression

### DIFF
--- a/sample/src/main/java/com/etiennelawlor/trestle/fragments/MainFragment.java
+++ b/sample/src/main/java/com/etiennelawlor/trestle/fragments/MainFragment.java
@@ -4,7 +4,6 @@ import android.graphics.Typeface;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.content.ContextCompat;
-import android.text.TextPaint;
 import android.text.method.LinkMovementMethod;
 import android.text.style.ClickableSpan;
 import android.view.LayoutInflater;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessParenthesesCheck - “ Useless parentheses around expressions should be removed to prevent any misunderstanding ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck

Please let me know if you have any questions.
Ayman Abdelghany.
