### PR TITLE
Change allowBackup to false

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.etiennelawlor.trestle.library">
 
-    <application android:allowBackup="true" android:label="@string/app_name"/>
+    <application android:allowBackup="false" android:label="@string/app_name"/>
 
 </manifest>


### PR DESCRIPTION
Setting allowBackup to true can be a security concern as adb backup allows users who have enabled USB debugging to copy application data off of the device. When working on an app where `allowBackup="false"` is required (such as using visa checkout), Trestle conflicts and the developer must use `tools:replace` to replace the setting in the Trestle manifest. Setting allowBackup to false removes the need to do this.